### PR TITLE
run any lsp from the configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 [dependencies]
 flate2 = "1.0"
 serde_json = "1.0"
-serde = {version = "1.0", features = ["derive"]}
+serde = { version = "1.0", features = ["derive"] }
 lapce-plugin = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,35 @@
 # lapce-python
 
+Fork of https://github.com/superlou/lapce-python
+
 ## Build
 
 ```
 rustup target add wasm32-wasi
 cargo build
 ```
+
+## Develop
+
+On OSX,
+
+```
+pip install pipx
+pipx install pylsp
+# adds ~/.local/bin/pylsp
+```
+
+```
+cd ~/.lapce/plugins
+mkdir lapce-python; cd lapce-python
+ln -s ~/prog/lapce-python/plugin.toml .
+ln -s ~/prog/lapce-python/target/wasm32-wasi/debug/lapce-python.wasm .
+```
+
+Run lapce from the terminal to see error messages. `lapce-python` should serialize its configuration to stderr.
+
+```
+RUST_BACKTRACE=1 /Applications/Lapce.app/Contents/MacOS/lapce
+```
+
+Unfortunately broken language servers seem to prevent lapce from being able to save.

--- a/plugin.toml
+++ b/plugin.toml
@@ -1,10 +1,14 @@
-sname = "lapce-python"
+name = "lapce-python"
 display-name = "Python"
-description = "Python for Lapce: powered by Jedi"
+description = "Python for Lapce: powered by https://github.com/python-lsp/python-lsp-server"
 version = "0.1.0"
-author = "superlou"
-repository = "superlou/lapce-python"
+author = "dholth"
+repository = "dholth/lapce-python"
 wasm = "lapce-python.wasm"
 
 [configuration]
+# language_id may not matter to lapce yet
 language_id = "python"
+executable = "/Users/dholth/.local/bin/pylsp"
+# options not passed to plugin?
+options = ["--log-file", "/Users/dholth/prog/lapce-python/log.txt"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use lapce_plugin::{register_plugin, start_lsp, LapcePlugin};
+use lapce_plugin::{register_plugin, send_notification, start_lsp, LapcePlugin};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
@@ -15,6 +15,7 @@ pub struct PluginInfo {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Configuration {
     language_id: String,
+    executable: String,
     options: Option<Value>,
 }
 
@@ -22,8 +23,6 @@ register_plugin!(State);
 
 impl LapcePlugin for State {
     fn initialize(&mut self, info: serde_json::Value) {
-        eprintln!("Starting lapce-python plugin!");
-
         let info = serde_json::from_value::<PluginInfo>(info).unwrap();
         let arch = match info.arch.as_str() {
             "x86_64" => "x86_64",
@@ -37,9 +36,22 @@ impl LapcePlugin for State {
             _ => return,
         };
 
-        // Well, this is a bad idea
-        let file_name = String::from("/home/lsimons/.local/bin/jedi-language-server");
+        // lapce-rust does this; is there any handler?
+        // let lock_file = PathBuf::from("download.lock");
+        // send_notification(
+        //     "python",
+        //     &json!({
+        //         "path": &lock_file,
+        //     }),
+        // );
 
-        start_lsp(&file_name, "python", info.configuration.options);
+        // two copies of us are started
+        serde_json::to_writer_pretty(std::io::stderr(), &info).unwrap();
+
+        start_lsp(
+            &info.configuration.executable,
+            "python",
+            info.configuration.options,
+        );
     }
 }


### PR DESCRIPTION
Thanks for creating lapce-python. I was able to get debugging output from the terminal, but it doesn't do anything for my Python code just yet. I copied lapce-rust's main.rs and edited it so that it just runs any language server from the configuration file.